### PR TITLE
Add support for custom map flags.

### DIFF
--- a/scripts/minimapapi/custom_mapflags.lua
+++ b/scripts/minimapapi/custom_mapflags.lua
@@ -1,0 +1,37 @@
+local MinimapAPI = require "scripts.minimapapi"
+
+MinimapAPI.SpriteMinimapIcons = Sprite()
+MinimapAPI.SpriteMinimapIcons:Load("gfx/ui/minimapapi_mapitemicons.anm2", true)
+
+local gameLvl = Game():GetLevel()
+
+local function TreasureMapCondition()
+	return gameLvl:GetStateFlag(LevelStateFlag.STATE_MAP_EFFECT)
+end
+
+local function BlueMapCondition()
+	return gameLvl:GetStateFlag(LevelStateFlag.STATE_BLUE_MAP_EFFECT)
+end
+
+local function CompassCondition()
+	return gameLvl:GetStateFlag(LevelStateFlag.STATE_COMPASS_EFFECT)
+end
+
+local function RestockCondition()
+	if Game():IsGreedMode() then return true end
+
+	for p = 0, Game():GetNumPlayers() - 1 do
+		player = Game():GetPlayer(p)
+
+		if player:HasCollectible(CollectibleType.COLLECTIBLE_RESTOCK) then
+			return true
+		end
+	end
+
+	return false
+end
+
+MinimapAPI:AddMapFlag("TreasureMap", TreasureMapCondition, MinimapAPI.SpriteMinimapIcons, "icons", 2)
+MinimapAPI:AddMapFlag("BlueMap", BlueMapCondition, MinimapAPI.SpriteMinimapIcons, "icons", 1)
+MinimapAPI:AddMapFlag("Compass", CompassCondition, MinimapAPI.SpriteMinimapIcons, "icons", 0)
+MinimapAPI:AddMapFlag("Restock", RestockCondition, MinimapAPI.SpriteMinimapIcons, "icons", 4)

--- a/scripts/minimapapi/data.lua
+++ b/scripts/minimapapi/data.lua
@@ -363,3 +363,14 @@ MinimapAPI.RoomShapeDoorSlots ={
 	{0,1,2,3,4,5,6,7}, -- ROOMSHAPE_LBL  
 	{0,1,2,3,4,5,6,7} -- ROOMSHAPE_LBR  
 }
+
+-- Map indicators, Added each flag from custom_mapflags.lua
+MinimapAPI.MapFlags = {
+	--[[ 
+	id: used to identify the flag
+	condition: return true to render the indicator
+	sprite: Mods should supply their own Sprite object where they load a custom anm2
+	anim: the name of the animation. "icons" for the regular icons
+	frame: frame of the icon. Can also be a function that returns a frame for indicators that might change frames (like zodiac indicator)
+	--]]
+}

--- a/scripts/minimapapi/init.lua
+++ b/scripts/minimapapi/init.lua
@@ -7,6 +7,7 @@ require("scripts.minimapapi.config")
 require("scripts.minimapapi.main")
 require("scripts.minimapapi.noalign")
 require("scripts.minimapapi.custom_icons")
+require("scripts.minimapapi.custom_mapflags")
 require("scripts.minimapapi.config_menu")
 require("scripts.minimapapi.testfunctions")
 


### PR DESCRIPTION
With this update modders can add custom map flags (restock, compass).
I tested adding map flags with a mod I'm currently called zodiac indicator.
Zodiac indicator shows you in the map flags what zodiac effect you are getting from the Zodiac item.

Flags can be added using `MinimapAPI.AddMapFlag` and removed using `MinimapAPI.RemoveMapFlag`:

```lua
MinimapAPI:AddMapFlag("Restock", RestockCondition, MinimapAPI.SpriteMinimapIcons, "icons", 4)
```

Documentation for each arg:

* id: used to identify the flag
* condition: a function that should return true to render the indicator
* sprite: Mods should supply their own Sprite object where they load a custom anm2
* anim: the name of the animation. "icons" for the regular icons
* frame: frame of the icon. Can also be a function that returns a frame for indicators that might change frames (like zodiac indicator) 