### PR TITLE
Fix Rep Dimensions, memory leak, and room:SetDisplayFlags

### DIFF
--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -161,26 +161,6 @@ function MinimapAPI:SetLevel(level)
 	MinimapAPI.Level = level
 end
 
-function MinimapAPI:ShallowCopy(t)
-	local t2 = {}
-	for i, v in pairs(t) do
-		t2[i] = v
-	end
-	return t2
-end
-
-function MinimapAPI:DeepCopy(t)
-	local t2 = {}
-	for i, v in pairs(t) do
-		if type(v) == "table" then
-			t2[i] = MinimapAPI:DeepCopy(v)
-		else
-			t2[i] = v
-		end
-	end
-	return t2
-end
-
 function MinimapAPI:GetIconAnimData(id)
 	for i, v in ipairs(MinimapAPI.IconList) do
 		if v.ID == id then

--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -464,14 +464,14 @@ end
 -- Level rooms:Get returns a constant room descriptor, 
 -- we need the mutable one returned by GetFromGridIdx
 -- for SetDisplayFlags to work
-local function GetRoomDescFromListIndex(listIndex, dimension)
+local function GetRoomDescFromListIndex(listIndex)
 	local level = Game():GetLevel()
     local constDesc = REVEL.level:GetRooms():Get(listIndex)
     if not constDesc then
         error(("GetRoomDescFromListIndex: bad index %d"):format(listIndex), 2)
     end
     local gridIndex = constDesc.GridIndex
-    return level:GetRoomByIdx(gridIndex, dimension)
+    return level:GetRoomByIdx(gridIndex)
 end
 
 function MinimapAPI:LoadDefaultMap()

--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -466,7 +466,7 @@ end
 -- for SetDisplayFlags to work
 local function GetRoomDescFromListIndex(listIndex)
 	local level = Game():GetLevel()
-    local constDesc = REVEL.level:GetRooms():Get(listIndex)
+    local constDesc = level:GetRooms():Get(listIndex)
     if not constDesc then
         error(("GetRoomDescFromListIndex: bad index %d"):format(listIndex), 2)
     end

--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -690,6 +690,8 @@ function MinimapAPI:RemoveRoomByID(id)
 	MinimapAPI:UpdateExternalMap()
 end
 
+---@param pos Vector
+---@return MinimapAPI.Room
 function MinimapAPI:GetRoom(pos)
 	assert(MinimapAPI:InstanceOf(pos, Vector), "bad argument #1 to 'GetRoom', expected Vector")
 	local success
@@ -702,6 +704,8 @@ function MinimapAPI:GetRoom(pos)
 	return success
 end
 
+---@param position Vector
+---@return MinimapAPI.Room
 function MinimapAPI:GetRoomAtPosition(position)
 	assert(MinimapAPI:InstanceOf(position, Vector), "bad argument #1 to 'GetRoomAtPosition', expected Vector")
 	for i, v in ipairs(MinimapAPI.Level) do
@@ -714,6 +718,8 @@ function MinimapAPI:GetRoomAtPosition(position)
 	end
 end
 
+---@param ID any
+---@return MinimapAPI.Room
 function MinimapAPI:GetRoomByID(ID)
 	for i, v in ipairs(MinimapAPI.Level) do
 		if v.ID == ID then
@@ -722,6 +728,8 @@ function MinimapAPI:GetRoomByID(ID)
 	end
 end
 
+---@param Idx integer
+---@return MinimapAPI.Room
 function MinimapAPI:GetRoomByIdx(Idx)
 	for i, v in ipairs(MinimapAPI.Level) do
 		if v.Descriptor and v.Descriptor.GridIndex == Idx then

--- a/scripts/minimapapi/rep/main.lua
+++ b/scripts/minimapapi/rep/main.lua
@@ -717,6 +717,8 @@ end
 ---@field NoUpdate boolean
 ---@field Dimension integer
 ---@field IgnoreDescriptorFlags boolean
+---@field TargetRenderOffset Vector
+---@field PlayerDistance number
 ---@field private AdjacentRooms MinimapAPI.Room[]
 local maproomfunctions = {}
 function maproomfunctions:IsVisible()
@@ -1990,7 +1992,7 @@ local function renderCallbackFunction(self)
 							if MinimapAPI.GlobalScaleX >= 0 then
 								minx = math.min(minx, v.RenderOffset.X)
 							else
-								local size = (MinimapAPI.IsLarge() and largeRoomSize or roomSize).X
+								local size = (MinimapAPI:IsLarge() and largeRoomSize or roomSize).X
 								minx = math.min(minx, v.RenderOffset.X + MinimapAPI.GlobalScaleX * MinimapAPI:GetRoomShapeGridSize(v.Shape).X * size - 6)
 							end
 						end

--- a/scripts/minimapapi/rep/main.lua
+++ b/scripts/minimapapi/rep/main.lua
@@ -696,10 +696,10 @@ end
 ---@field Type RoomType
 ---@field ID any
 ---@field Shape RoomShape
----@field PermanentIcons table
----@field LockedIcons table
----@field ItemIcons table
----@field VisitedIcons table
+---@field PermanentIcons string[]
+---@field LockedIcons string[]
+---@field ItemIcons string[]
+---@field VisitedIcons string[]
 ---@field Descriptor RoomDescriptor
 ---@field Color Color
 ---@field RenderOffset Vector

--- a/scripts/minimapapi/rep/main.lua
+++ b/scripts/minimapapi/rep/main.lua
@@ -548,8 +548,10 @@ end
 -- we need the mutable one returned by GetFromGridIdx
 -- for SetDisplayFlags to work
 local function GetRoomDescFromListIndex(listIndex, dimension)
-	local level = Game():GetLevel()
-    local constDesc = REVEL.level:GetRooms():Get(listIndex)
+	local level = game:GetLevel()
+    local constDesc = level:GetRooms():Get(listIndex)
+	-- return constDesc
+
     if not constDesc then
         error(("GetRoomDescFromListIndex: bad index %d"):format(listIndex), 2)
     end

--- a/scripts/minimapapi/rep/main.lua
+++ b/scripts/minimapapi/rep/main.lua
@@ -566,7 +566,7 @@ function MinimapAPI:LoadDefaultMap(dimension)
 	local treasure_room_count = 0
 	local added_descriptors = {}
 	for i = 0, #rooms - 1 do
-		local v = GetRoomDescFromListIndex(i)
+		local v = GetRoomDescFromListIndex(i, dimension)
 		local hash = GetPtrHash(v)
 		if not added_descriptors[v] and GetPtrHash(cache.Level:GetRoomByIdx(v.SafeGridIndex)) == hash then
 			added_descriptors[v] = true
@@ -661,7 +661,7 @@ function MinimapAPI:CheckForNewRedRooms(dimension)
 	local level = MinimapAPI.Levels[dimension]
 	local added_descriptors = {}
 	for i = MinimapAPI.CheckedRoomCount, #rooms - 1 do
-		local v = GetRoomDescFromListIndex(i)
+		local v = GetRoomDescFromListIndex(i, dimension)
 		local hash = GetPtrHash(v)
 		if not added_descriptors[v] and GetPtrHash(cache.Level:GetRoomByIdx(v.GridIndex)) == hash then
 			added_descriptors[v] = true
@@ -1870,7 +1870,7 @@ function MinimapAPI:LoadSaveTable(saved,is_save)
 						PermanentIcons = v.PermanentIcons,
 						LockedIcons = v.LockedIcons,
 						VisitedIcons = v.VisitedIcons,
-						Descriptor = v.DescriptorListIndex and GetRoomDescFromListIndex(v.DescriptorListIndex),
+						Descriptor = v.DescriptorListIndex and GetRoomDescFromListIndex(v.DescriptorListIndex, dim),
 						DisplayFlags = v.DisplayFlags,
 						Clear = v.Clear,
 						Color = v.Color and Color(v.Color.R, v.Color.G, v.Color.B, v.Color.A, v.Color.RO, v.Color.GO, v.Color.BO),


### PR DESCRIPTION
As rooms used constant RoomDescriptors from rooms:Get, SetDisplayFlags didn't work

Edit: 
Fixing this ended up in fixing the memory leak caused by DeepCopy() (replaced by a room-specific CopyRoom() that doesn't copy the AdjacentRooms table, as it wasn't used anywhere else), and a bug with saving .Levels
It looks like MinimapAPI.Levels is supposed to have a key for each dimension, but the way the rooms were loaded in the table loaded all rooms from all dimensions in key 0, which ended up in the rooms from the higher dimensions rendering over the ones from the lower ones after fixing other things; now rooms should end up in the proper key on load. Haven't tested all possible edge cases as no time, sadly.

Also included some EmmyLua annotations for MinimapAPI.Room while I was at it