### PR TITLE
Hurt player if teleporting to/from Curse Room

### DIFF
--- a/scripts/minimapapi/nicejourney.lua
+++ b/scripts/minimapapi/nicejourney.lua
@@ -57,6 +57,7 @@ local enteringCurseRoom = false
 
 ---@param room MinimapAPI.Room # target room
 ---@param curRoom MinimapAPI.Room # room we're teleporting from
+---@return should player be hurt from entering or exiting a curse room
 local function niceJourney_ShouldDamagePlayer(room, curRoom)
 	enteringCurseRoom = room.Descriptor.Data.Type == RoomType.ROOM_CURSE
 	leavingCurseRoom = (curRoom.Descriptor and curRoom.Descriptor.Data.Type == RoomType.ROOM_CURSE)
@@ -94,12 +95,10 @@ local function niceJourney_ShouldDamagePlayer(room, curRoom)
 		end
 	end
 
-	Isaac.DebugString("enteringCurseRoom: "..tostring(enteringCurseRoom).." leavingCurseRoom: "..tostring(leavingCurseRoom))
 	if leavingCurseRoom or enteringCurseRoom then
-
 		for i = 0, Game:GetNumPlayers() - 1 do
-			if Isaac.GetPlayer(i):HasTrinket(TrinketType.TRINKET_FLAT_FILE) then
-				Isaac.DebugString("found flat file")
+			if Isaac.GetPlayer(i):HasTrinket(TrinketType.TRINKET_FLAT_FILE)
+			or Isaac.GetPlayer(i):HasCollectible(CollectibleType.COLLECTIBLE_ISAACS_HEART) then
 				return false
 			end
 		end


### PR DESCRIPTION
Fixes issue #80. When a map teleport is initiated, checks if the current room or destination room is a curse room. If either are true, check appropriate conditions (player has flight/door has been made harmless by Flat File/an alternate safe exit exists) and hurt player if no condition applies.

First time contributing to MinimapAPI, please review for code style/function.