### PR TITLE
Fix #82 and #83

### DIFF
--- a/scripts/minimapapi/nicejourney.lua
+++ b/scripts/minimapapi/nicejourney.lua
@@ -63,7 +63,7 @@ local function ShouldDamagePlayer(room, curRoom)
     local enteringCurseRoom = room.Descriptor.Data.Type == RoomType.ROOM_CURSE
     local leavingCurseRoom = curRoom.Data.Type == RoomType.ROOM_CURSE
 
-    if not (enteringCurseRoom or leavingCurseRoom) or MinimapAPI:GetConfig("MouseTeleportDamageOnCurseRoom") then
+    if not (enteringCurseRoom or leavingCurseRoom) or not MinimapAPI:GetConfig("MouseTeleportDamageOnCurseRoom") then
         return false
     end
 

--- a/scripts/minimapapi/nicejourney.lua
+++ b/scripts/minimapapi/nicejourney.lua
@@ -54,7 +54,7 @@ function _telHandlerTemplate:CanTeleport(room, cheatMode)
 end
 
 ---@param room MinimapAPI.Room # target room
----@param curRoom MinimapAPI.Room # room we're teleporting from
+---@param curRoom RoomDescriptor # room we're teleporting from
 ---@return boolean # should player be hurt from entering or exiting a curse room
 local function ShouldDamagePlayer(room, curRoom)
     if type(curRoom) == "nil" then
@@ -94,7 +94,7 @@ local function ShouldDamagePlayer(room, curRoom)
 end
 
 ---@param room MinimapAPI.Room # target room
----@param curRoom MinimapAPI.Room # room we're teleporting from
+---@param curRoom RoomDescriptor # room we're teleporting from
 ---@return boolean # is player allowed to teleport
 local function CanTeleportToRoom(room, curRoom)
     local onMomFloor = (level:GetStage() == 6


### PR DESCRIPTION
- Fixes the teleport exploits in #82
- Fixes #83 by using `level:GetCurrentRoomDesc()` instead of `MinimapAPI:GetCurrentRoom()` and implementing better error checking in case `curRoom` is somehow still `nil`