### PR TITLE
Prevent teleporting while mineshaft escape sequence is active

### DIFF
--- a/scripts/minimapapi/nicejourney.lua
+++ b/scripts/minimapapi/nicejourney.lua
@@ -132,6 +132,8 @@ local function CanTeleportToRoom(room, curRoom)
             else
                 return allPlayersFullHealth
             end
+        elseif (REPENTANCE and level:GetStateFlag(LevelStateFlag.STATE_MINESHAFT_ESCAPE)) then
+            return MinimapAPI.CurrentDimension ~= 1
         else
             return true
         end


### PR DESCRIPTION
1. It's cheese
2. It bugs out the minimap when you do so
(You can still do it with cheat mode active, but it doesn't address point 2...)