### PR TITLE
Allow multiple room icons to properly show

### DIFF
--- a/scripts/minimapapi/data.lua
+++ b/scripts/minimapapi/data.lua
@@ -318,6 +318,7 @@ MinimapAPI.IconList = {
 	--{ID="GreedExit",anim="",frame=0},  --currently no icon
 	{ID="Planetarium",anim="IconPlanetarium",frame=0},
 	{ID="TeleporterRoom",anim="IconTeleporterRoom",frame=0}, -- unused in vanilla but some mods may use it
+	{ID="TreasureRoomRed",anim="IconTreasureRoomRed",frame=0},
 	{ID="UltraSecretRoom",anim="IconUltraSecretRoom",frame=0},
 	--Quests
 	{ID="MirrorRoom",anim="IconMirrorRoom",frame=0},

--- a/scripts/minimapapi/data.lua
+++ b/scripts/minimapapi/data.lua
@@ -181,8 +181,8 @@ MinimapAPI.RoomTypeIconIDs = {
 }
 if REPENTANCE then
 	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_PLANETARIUM] = "Planetarium"
-	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_TELEPORTER] = nil
-	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_TELEPORTER_EXIT] = nil
+	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_TELEPORTER] = "TeleporterRoom"
+	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_TELEPORTER_EXIT] = "TeleporterRoom"
 	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_SECRET_EXIT] = nil
 	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_BLUE] = nil
 	MinimapAPI.RoomTypeIconIDs[RoomType.ROOM_ULTRASECRET] = "UltraSecretRoom"
@@ -317,6 +317,7 @@ MinimapAPI.IconList = {
 	{ID="TreasureRoomGreed",anim="IconTreasureRoomGreed",frame=0},
 	--{ID="GreedExit",anim="",frame=0},  --currently no icon
 	{ID="Planetarium",anim="IconPlanetarium",frame=0},
+	{ID="TeleporterRoom",anim="IconTeleporterRoom",frame=0}, -- unused in vanilla but some mods may use it
 	{ID="UltraSecretRoom",anim="IconUltraSecretRoom",frame=0},
 	--Quests
 	{ID="MirrorRoom",anim="IconMirrorRoom",frame=0},

--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -620,22 +620,22 @@ function MinimapAPI:LoadDefaultMap(dimension)
 				Visited = roomDescriptor.VisitedCount > 0,
 				Clear = roomDescriptor.Clear,
 				Color = REPENTANCE and roomDescriptor.Flags & RoomDescriptor.FLAG_RED_ROOM == RoomDescriptor.FLAG_RED_ROOM and Color(1,0.25,0.25,1,0,0,0) or nil
-		}
-		if roomDescriptor.Data.Type == RoomType.ROOM_SECRET or roomDescriptor.Data.Type == RoomType.ROOM_SUPERSECRET then
+			}
+			
+			if roomDescriptor.Data.Type == RoomType.ROOM_SECRET or roomDescriptor.Data.Type == RoomType.ROOM_SUPERSECRET then
 				t.Hidden = 1
 			elseif REPENTANCE and roomDescriptor.Data.Type == RoomType.ROOM_ULTRASECRET then
 				t.Hidden = 2
 			end
-			if roomDescriptor.Data.Type == 11 and roomDescriptor.Data.Subtype == 1 then
-				t.PermanentIcons[1] = "BossAmbushRoom"
+			if roomDescriptor.Data.Type == RoomType.ROOM_CHALLENGE and roomDescriptor.Data.Subtype == 1 then
+				t.PermanentIcons = {"BossAmbushRoom"}
+			end
+			if REPENTANCE and roomDescriptor.Flags & RoomDescriptor.FLAG_DEVIL_TREASURE == RoomDescriptor.FLAG_DEVIL_TREASURE then
+				t.PermanentIcons = {"TreasureRoomRed"}
 			end
 			if override_greed and game:IsGreedMode() then
-				if roomDescriptor.Data.Type == RoomType.ROOM_TREASURE then
-					treasure_room_count = treasure_room_count + 1
-					if treasure_room_count == 1 then
-						t.PermanentIcons = {"TreasureRoomGreed"}
-						t.LockedIcons = {"TreasureRoomGreed"}
-					end
+				if roomDescriptor.Data.Type == RoomType.ROOM_TREASURE and roomDescriptor.GridIndex == 98 then
+					t.PermanentIcons = {"TreasureRoomGreed"}
 				end
 			end
 			MinimapAPI:AddRoom(t)
@@ -751,8 +751,11 @@ function MinimapAPI:CheckForNewRedRooms(dimension)
 			elseif roomDescriptor.Data.Type == RoomType.ROOM_ULTRASECRET then
 				t.Hidden = 2
 			end
+			if REPENTANCE and roomDescriptor.Flags & RoomDescriptor.FLAG_DEVIL_TREASURE == RoomDescriptor.FLAG_DEVIL_TREASURE then
+				t.PermanentIcons = {"TreasureRoomRed"}
+			end
 			if roomDescriptor.Data.Type == 11 and roomDescriptor.Data.Subtype == 1 then
-				t.PermanentIcons[1] = "BossAmbushRoom"
+				t.PermanentIcons = {"BossAmbushRoom"}
 			end
 			
 			MinimapAPI:AddRoom(t)
@@ -904,6 +907,18 @@ function maproomfunctions:UpdateType()
 	if self.Descriptor and self.Descriptor.Data then
 		self.Type = self.Descriptor.Data.Type
 		self.PermanentIcons = {MinimapAPI:GetRoomTypeIconID(self.Type)}
+		
+		if self.Descriptor.Data.Type == RoomType.ROOM_CHALLENGE and self.Descriptor.Data.Subtype == 1 then
+			self.PermanentIcons = {"BossAmbushRoom"}
+		end
+		if REPENTANCE and self.Descriptor.Flags & RoomDescriptor.FLAG_DEVIL_TREASURE == RoomDescriptor.FLAG_DEVIL_TREASURE then
+			self.PermanentIcons = {"TreasureRoomRed"}
+		end
+		if override_greed and game:IsGreedMode() then
+			if self.Descriptor.Data.Type == RoomType.ROOM_TREASURE and self.Descriptor.GridIndex == 98 then
+				self.PermanentIcons = {"TreasureRoomGreed"}
+			end
+		end
 	end
 end
 
@@ -1982,6 +1997,13 @@ local function renderCallbackFunction(self)
 				if not v.Hidden and #v.PermanentIcons > 0 then
 					v.DisplayFlags = v.DisplayFlags | 6
 				end
+			end
+		end
+		
+		-- treasure rooms are the only room with a permanent icon that can dynamically change (devil's crown), so we have to constantly update its type
+		for _,v in ipairs(MinimapAPI:GetLevel()) do
+			if v.Type == RoomType.ROOM_TREASURE then
+				v:UpdateType()
 			end
 		end
 


### PR DESCRIPTION
These room icons being Devil's Crown treasure rooms and Teleporter rooms (which are unused but some mods do use).
Devil's Crown dynamically changes with the trinket as well.
Also made the greed mode silver treasure room check use a faster method.
![20220814193242_1](https://user-images.githubusercontent.com/23617175/184560952-4b54ed03-173b-4005-9b19-151c311cc66c.jpg)

