### PR TITLE
Fix incorrect reference in PR #101

### DIFF
--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -992,7 +992,7 @@ function maproomfunctions:SyncRoomDescriptor()
 		
 		if self.Descriptor.Data.Type == RoomType.ROOM_SECRET or self.Descriptor.Data.Type == RoomType.ROOM_SUPERSECRET then
 			self.Hidden = 1
-		elseif REPENTANCE and roomDescriptor.Data.Type == RoomType.ROOM_ULTRASECRET then
+		elseif REPENTANCE and self.Descriptor.Data.Type == RoomType.ROOM_ULTRASECRET then
 			self.Hidden = 2
 		end
 


### PR DESCRIPTION
SyncRoomDescriptors accidentally tries to invoke a nonexistent `roomDescriptor` variable, which errors on use. This changes it to `self.Descriptor` to match the rest of the function.