### PR TITLE
Do various changes for latest rep patch

### DIFF
--- a/scripts/minimapapi/custom_icons.lua
+++ b/scripts/minimapapi/custom_icons.lua
@@ -43,6 +43,7 @@ MinimapAPI:AddIcon("DiceShard", MinimapAPI.CustomIcons, "CustomIconDiceShard", 0
 MinimapAPI:AddIcon("MagicCard", MinimapAPI.CustomIcons, "CustomIconMagicCard", 0)
 
 MinimapAPI:AddIcon("ShellGame", MinimapAPI.CustomIcons, "CustomIconShellGame", 0)
+MinimapAPI:AddIcon("HeavenDoor", MinimapAPI.CustomIcons, "CustomIconHeavenDoor", 0)
 if REPENTANCE then -- Repentance exclusive icons
 	MinimapAPI:AddIcon("KeyShard", MinimapAPI.CustomIcons, "CustomIconKeyShard", 0)
 
@@ -59,78 +60,68 @@ if REPENTANCE then -- Repentance exclusive icons
 
 	MinimapAPI:AddIcon("BigPoopNugget", MinimapAPI.CustomIcons, "CustomIconPoop", 1)
 	MinimapAPI:AddIcon("WhiteFireplace", MinimapAPI.CustomIcons, "CustomIconWhiteFireplace", 0)
-	MinimapAPI:AddIcon("HeavenDoor", MinimapAPI.CustomIcons, "CustomIconHeavenDoor", 0)
 end
+local itemConfig = Isaac.GetItemConfig()
 
-MinimapAPI:AddPickup("PillBlueBlue","PillBlueBlue",5,70,PillColor.PILL_BLUE_BLUE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillOrangeOrange","PillOrangeOrange",5,70,PillColor.PILL_ORANGE_ORANGE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillWhiteWhite","PillWhiteWhite",5,70,PillColor.PILL_WHITE_WHITE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillReddotsRed","PillReddotsRed",5,70,PillColor.PILL_REDDOTS_RED,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillPinkRed","PillPinkRed",5,70,PillColor.PILL_PINK_RED,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillBlueCadetblue","PillBlueCadetblue",5,70,PillColor.PILL_BLUE_CADETBLUE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillYellowOrange","PillYellowOrange",5,70,PillColor.PILL_YELLOW_ORANGE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillOrangedotsWhite","PillOrangedotsWhite",5,70,PillColor.PILL_ORANGEDOTS_WHITE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillWhiteAzure","PillWhiteAzure",5,70,PillColor.PILL_WHITE_AZURE,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillBlackYellow","PillBlackYellow",5,70,PillColor.PILL_BLACK_YELLOW,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillWhiteBlack","PillWhiteBlack",5,70,PillColor.PILL_WHITE_BLACK,MinimapAPI.PickupNotCollected,"pills",6100)
-MinimapAPI:AddPickup("PillWhiteYellow","PillWhiteYellow",5,70,PillColor.PILL_WHITE_YELLOW,MinimapAPI.PickupNotCollected,"pills",6100)
+MinimapAPI:AddPickup("Trophy","CheckeredFlag",5,370,-1,nil,"trophies",15000)
+MinimapAPI:AddPickup("BigChest","CheckeredFlag",5,340,-1,nil,"trophies",15000)
+MinimapAPI:AddPickup("Shovel","Shovel",5,110,-1,nil,"trophies",15000)
 
+MinimapAPI:AddPickup("DoubleHeart","DoubleHeart",5,10,5,MinimapAPI.PickupNotCollected,"hearts",14150)
 
-MinimapAPI:AddPickup("DoubleHeart","DoubleHeart",5,10,5,MinimapAPI.PickupNotCollected,"hearts",10200)
-MinimapAPI:AddPickup("DoublePenny","DoublePenny",5,20,4,MinimapAPI.PickupNotCollected,"coins",3200)
-MinimapAPI:AddPickup("Nickel","Nickel",5,20,2,MinimapAPI.PickupNotCollected,"coins",3400)
-MinimapAPI:AddPickup("StickyNickel","Nickel",5,20,6,MinimapAPI.PickupNotCollected,"coins",3300)
-MinimapAPI:AddPickup("Dime","Dime",5,20,3,MinimapAPI.PickupNotCollected,"coins",3600)
-MinimapAPI:AddPickup("LuckyPenny","LuckyPenny",5,20,5,MinimapAPI.PickupNotCollected,"coins",3500)
-MinimapAPI:AddPickup("KeyRing","KeyRing",5,30,3,MinimapAPI.PickupNotCollected,"keys",5100)
-MinimapAPI:AddPickup("DoubleBomb","DoubleBomb",5,40,2,MinimapAPI.PickupNotCollected,"bombs",4100)
+MinimapAPI:AddPickup("RuneBlack","RuneBlack",5,300,-1,MinimapAPI.PickupNotCollected,"runes",10050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 7 end)
+MinimapAPI:AddPickup("RuneRight","RuneRight",5,300,-1,MinimapAPI.PickupNotCollected,"runes",10000,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 4 end)
 
-MinimapAPI:AddPickup("Card","TarotCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",1000)
-for i=23,31 do
-	MinimapAPI:AddPickup("SuitCard"..i,"SuitCard",5,300,i,MinimapAPI.PickupNotCollected,"cards",1100)
-end
-for i=36,40 do
-	MinimapAPI:AddPickup("Rune"..i,"RuneRight",5,300,i,MinimapAPI.PickupNotCollected,"runes",1100)
-end
-MinimapAPI:AddPickup("Rune41","RuneBlack",5,300,41,MinimapAPI.PickupNotCollected,"runes",1200)--Black rune
-MinimapAPI:AddPickup("ChaosCard","MagicCard",5,300,42,MinimapAPI.PickupNotCollected,"cards",1100)--Chaos Card
-MinimapAPI:AddPickup("RulesCard","SuitCard",5,300,44,MinimapAPI.PickupNotCollected,"cards",1100)--Rules Card
-MinimapAPI:AddPickup("SuicideKing","SuitCard",5,300,46,MinimapAPI.PickupNotCollected,"cards",1100)--Suicide King
-MinimapAPI:AddPickup("QuestionmarkCard","SuitCard",5,300,48,MinimapAPI.PickupNotCollected,"cards",1100)--?Card 
-MinimapAPI:AddPickup("CreditCard","CreditCard",5,300,43,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("GetOutOfJail","GetOutOfJail",5,300,47,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("CardAgainstHumanity","CardAgainstHumanity",5,300,45,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("HolyCard","HolyCard",5,300,51,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("MomsContract","MomsContract",5,300,50,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("DiceShard","DiceShard",5,300,49,MinimapAPI.PickupNotCollected,"cards",1100)
+MinimapAPI:AddPickup("SuitCard","SuitCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 2 end)
+MinimapAPI:AddPickup("MomsContract","MomsContract",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 5 end)
+MinimapAPI:AddPickup("DiceShard","DiceShard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 6 end)
+MinimapAPI:AddPickup("MagicCard","MagicCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 8 end)
+MinimapAPI:AddPickup("CardAgainstHumanity","CardAgainstHumanity",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 9 end)
+MinimapAPI:AddPickup("CreditCard","CreditCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 10 end)
+MinimapAPI:AddPickup("HolyCard","HolyCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 11 end)
+MinimapAPI:AddPickup("GetOutOfJail","GetOutOfJail",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 12 end)
+MinimapAPI:AddPickup("TarotCard","TarotCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9000,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 1 end)
 
-MinimapAPI:AddPickup("HugeGrowth","MagicCard",5,300,52,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("AncientRecall","MagicCard",5,300,53,MinimapAPI.PickupNotCollected,"cards",1100)
-MinimapAPI:AddPickup("EraWalk","MagicCard",5,300,54,MinimapAPI.PickupNotCollected,"cards",1100)
+MinimapAPI:AddPickup("PillBlueBlue","PillBlueBlue",5,70,PillColor.PILL_BLUE_BLUE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillOrangeOrange","PillOrangeOrange",5,70,PillColor.PILL_ORANGE_ORANGE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillWhiteWhite","PillWhiteWhite",5,70,PillColor.PILL_WHITE_WHITE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillReddotsRed","PillReddotsRed",5,70,PillColor.PILL_REDDOTS_RED,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillPinkRed","PillPinkRed",5,70,PillColor.PILL_PINK_RED,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillBlueCadetblue","PillBlueCadetblue",5,70,PillColor.PILL_BLUE_CADETBLUE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillYellowOrange","PillYellowOrange",5,70,PillColor.PILL_YELLOW_ORANGE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillOrangedotsWhite","PillOrangedotsWhite",5,70,PillColor.PILL_ORANGEDOTS_WHITE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillWhiteAzure","PillWhiteAzure",5,70,PillColor.PILL_WHITE_AZURE,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillBlackYellow","PillBlackYellow",5,70,PillColor.PILL_BLACK_YELLOW,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillWhiteBlack","PillWhiteBlack",5,70,PillColor.PILL_WHITE_BLACK,MinimapAPI.PickupNotCollected,"pills",8000)
+MinimapAPI:AddPickup("PillWhiteYellow","PillWhiteYellow",5,70,PillColor.PILL_WHITE_YELLOW,MinimapAPI.PickupNotCollected,"pills",8000)
 
-MinimapAPI:AddPickup("Trophy","CheckeredFlag",5,370,-1,nil,"trophies",13000)
-MinimapAPI:AddPickup("BigChest","CheckeredFlag",5,340,-1,nil,"trophies",13000)
-MinimapAPI:AddPickup("Shovel","Shovel",5,110,-1,nil,"trophies",13000)
+MinimapAPI:AddPickup("KeyRing","KeyRing",5,30,3,MinimapAPI.PickupNotCollected,"keys",7050)
 
-MinimapAPI:AddPickup("ShellGame","ShellGame",6,6,-1,MinimapAPI.PickupSlotMachineNotBroken,"beggars",100)
+MinimapAPI:AddPickup("DoubleBomb","DoubleBomb",5,40,2,MinimapAPI.PickupNotCollected,"bombs",6050)
+
+MinimapAPI:AddPickup("Dime","Dime",5,20,3,MinimapAPI.PickupNotCollected,"coins",4090)
+MinimapAPI:AddPickup("LuckyPenny","LuckyPenny",5,20,5,MinimapAPI.PickupNotCollected,"coins",4080)
+MinimapAPI:AddPickup("Nickel","Nickel",5,20,2,MinimapAPI.PickupNotCollected,"coins",4070)
+MinimapAPI:AddPickup("StickyNickel","Nickel",5,20,6,MinimapAPI.PickupNotCollected,"coins",4060)
+MinimapAPI:AddPickup("DoublePenny","DoublePenny",5,20,4,MinimapAPI.PickupNotCollected,"coins",4050)
+
+MinimapAPI:AddPickup("ShellGame","ShellGame",6,6,-1,MinimapAPI.PickupSlotMachineNotBroken,"beggars",2050)
+
 MinimapAPI:AddPickup("HeavenDoor","HeavenDoor",1000,39,0,function(p) return Game():GetLevel():IsAscent() or Isaac.GetChallenge() == Challenge.CHALLENGE_BACKASSWARDS end,"quest",100) --IsAscent() should always be false in ab+
 
 if REPENTANCE then -- Repentance exclusive icons
-	for i=56,77 do
-		MinimapAPI:AddPickup("Reverse"..i,"ReverseCard",5,300,i,MinimapAPI.PickupNotCollected,"cards",1100)
-	end
-
-	MinimapAPI:AddPickup("KeyShard","KeyShard",5,300,78,MinimapAPI.PickupNotCollected,"cards",1200)
-	MinimapAPI:AddPickup("QueenOfHearts","SuitCard",5,300,79,MinimapAPI.PickupNotCollected,"cards",1200)
-
 	for i=81,97 do
-		MinimapAPI:AddPickup("Soul"..i,"Soul"..i,5,300,i,MinimapAPI.PickupNotCollected,"runes",1300)
+		MinimapAPI:AddPickup("Soul"..i,"Soul"..i,5,300,i,MinimapAPI.PickupNotCollected,"runes",10050) -- so many souls this is just easier
 	end
+	MinimapAPI:AddPickup("RuneShard","RuneShard",5,300,-1,MinimapAPI.PickupNotCollected,"runes",10000,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 13 end)
 
-	MinimapAPI:AddPickup("WildCard","UnusCard",5,300,80,MinimapAPI.PickupNotCollected,"cards",1200)
-	MinimapAPI:AddPickup("RuneShard","RuneShard",5,300,55,MinimapAPI.PickupNotCollected,"runes",1100)
-	MinimapAPI:AddPickup("HellGame","HellGame",6,15,-1,MinimapAPI.PickupSlotMachineNotBroken,"beggars",300)
+	MinimapAPI:AddPickup("ReverseCard","ReverseCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 14 end)
+	MinimapAPI:AddPickup("KeyShard","KeyShard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 15 end)
+	MinimapAPI:AddPickup("UnusCard","UnusCard",5,300,-1,MinimapAPI.PickupNotCollected,"cards",9050,function(p) return itemConfig:GetCard(p.SubType).PickupSubtype == 17 end)
 
-	MinimapAPI:AddPickup("BigPoopNugget","BigPoopNugget",5,42,1,MinimapAPI.PickupNotCollected,"bombs",1200)
+	MinimapAPI:AddPickup("HellGame","HellGame",6,15,-1,MinimapAPI.PickupSlotMachineNotBroken,"beggars",2250)
+
+	MinimapAPI:AddPickup("BigPoopNugget","BigPoopNugget",5,42,1,MinimapAPI.PickupNotCollected,"poops",5050)
+
 	MinimapAPI:AddPickup("WhiteFireplace","WhiteFireplace",33,4,-1,nil,"quest",100)
 end

--- a/scripts/minimapapi/custom_mapflags.lua
+++ b/scripts/minimapapi/custom_mapflags.lua
@@ -6,39 +6,39 @@ MinimapAPI.SpriteMinimapIcons:Load("gfx/ui/minimapapi_mapitemicons.anm2", true)
 local game = Game()
 local gameLvl = game:GetLevel()
 
-local function MindCondition()
-	return gameLvl:GetStateFlag(LevelStateFlag.STATE_FULL_MAP_EFFECT) or (gameLvl:GetStateFlag(LevelStateFlag.STATE_MAP_EFFECT) and gameLvl:GetStateFlag(LevelStateFlag.STATE_BLUE_MAP_EFFECT) and gameLvl:GetStateFlag(LevelStateFlag.STATE_COMPASS_EFFECT))
-end
-
-local function TreasureMapCondition()
-	if MindCondition() then return false end
-
-	return gameLvl:GetStateFlag(LevelStateFlag.STATE_MAP_EFFECT)
-end
-
-local function BlueMapCondition()
-	if MindCondition() then return false end
-	return gameLvl:GetStateFlag(LevelStateFlag.STATE_BLUE_MAP_EFFECT)
-end
-
-local function CompassCondition()
-	if MindCondition() then return false end
-
-	return gameLvl:GetStateFlag(LevelStateFlag.STATE_COMPASS_EFFECT)
-end
-
-local function RestockCondition()
-	if game:IsGreedMode() then return true end
-
+local function anyPlayerHasCollectible(collectible)
 	for p = 0, game:GetNumPlayers() - 1 do
 		local player = game:GetPlayer(p)
-
-		if player:HasCollectible(CollectibleType.COLLECTIBLE_RESTOCK) then
+		if player:HasCollectible(collectible) then
 			return true
 		end
 	end
 
 	return false
+end
+
+local function MindCondition()
+	return anyPlayerHasCollectible(CollectibleType.COLLECTIBLE_MIND)
+end
+
+local function TreasureMapCondition()
+	if MindCondition() then return false end
+	return anyPlayerHasCollectible(CollectibleType.COLLECTIBLE_TREASURE_MAP)
+end
+
+local function BlueMapCondition()
+	if MindCondition() then return false end
+	return anyPlayerHasCollectible(CollectibleType.COLLECTIBLE_BLUE_MAP)
+end
+
+local function CompassCondition()
+	if MindCondition() then return false end
+	return anyPlayerHasCollectible(CollectibleType.COLLECTIBLE_COMPASS)
+end
+
+local function RestockCondition()
+	if game:IsGreedMode() then return true end
+	return anyPlayerHasCollectible(CollectibleType.COLLECTIBLE_RESTOCK)
 end
 
 local function DarknessCurse()

--- a/scripts/minimapapi/data.lua
+++ b/scripts/minimapapi/data.lua
@@ -229,78 +229,80 @@ MinimapAPI.PickupSlotMachineNotBroken = slotNotDead
 MinimapAPI.PickupDresserNotDead = dresserNotDead
 
 MinimapAPI.PickupList = {
-	["RottenHeart"] = {IconID="RottenHeart",Type=5,Variant=10,SubType=12,Call=notCollected,IconGroup="hearts",Priority=11000},
-	["WhiteHeart"] = {IconID="WhiteHeart",Type=5,Variant=10,SubType=4,Call=notCollected,IconGroup="hearts",Priority=10900},
-	["GoldHeart"] = {IconID="GoldHeart",Type=5,Variant=10,SubType=7,Call=notCollected,IconGroup="hearts",Priority=10800},
-	["BoneHeart"] = {IconID="BoneHeart",Type=5,Variant=10,SubType=11,Call=notCollected,IconGroup="hearts",Priority=10700},
-	["BlackHeart"] = {IconID="BlackHeart",Type=5,Variant=10,SubType=6,Call=notCollected,IconGroup="hearts",Priority=10600},
-	["BlueHeart"] = {IconID="BlueHeart",Type=5,Variant=10,SubType=3,Call=notCollected,IconGroup="hearts",Priority=10500},
-	["BlendedHeart"] = {IconID="BlendedHeart",Type=5,Variant=10,SubType=10,Call=notCollected,IconGroup="hearts",Priority=10400},
-	["HalfBlueHeart"] = {IconID="HalfBlueHeart",Type=5,Variant=10,SubType=8,Call=notCollected,IconGroup="hearts",Priority=10300},
-	["ScaredHeart"] = {IconID="Heart",Type=5,Variant=10,SubType=9,Call=notCollected,IconGroup="hearts",Priority=10100},
-	["DoubleHeart"] = {IconID="Heart",Type=5,Variant=10,SubType=5,Call=notCollected,IconGroup="hearts",Priority=10100},
-	["Heart"] = {IconID="Heart",Type=5,Variant=10,SubType=1,Call=notCollected,IconGroup="hearts",Priority=10100},
-	["HalfHeart"] = {IconID="HalfHeart",Type=5,Variant=10,SubType=2,Call=notCollected,IconGroup="hearts",Priority=10000},
+	["WhiteHeart"] = {IconID="WhiteHeart",Type=5,Variant=10,SubType=4,Call=notCollected,IconGroup="hearts",Priority=14900},
+	["GoldHeart"] = {IconID="GoldHeart",Type=5,Variant=10,SubType=7,Call=notCollected,IconGroup="hearts",Priority=14800},
+	["BoneHeart"] = {IconID="BoneHeart",Type=5,Variant=10,SubType=11,Call=notCollected,IconGroup="hearts",Priority=14700},
+	["BlackHeart"] = {IconID="BlackHeart",Type=5,Variant=10,SubType=6,Call=notCollected,IconGroup="hearts",Priority=14600},
+	["BlueHeart"] = {IconID="BlueHeart",Type=5,Variant=10,SubType=3,Call=notCollected,IconGroup="hearts",Priority=14500},
+	["BlendedHeart"] = {IconID="BlendedHeart",Type=5,Variant=10,SubType=10,Call=notCollected,IconGroup="hearts",Priority=14400},
+	["HalfBlueHeart"] = {IconID="HalfBlueHeart",Type=5,Variant=10,SubType=8,Call=notCollected,IconGroup="hearts",Priority=14300},
+	["RottenHeart"] = {IconID="RottenHeart",Type=5,Variant=10,SubType=12,Call=notCollected,IconGroup="hearts",Priority=14200},
+	["ScaredHeart"] = {IconID="Heart",Type=5,Variant=10,SubType=9,Call=notCollected,IconGroup="hearts",Priority=14100},
+	["DoubleHeart"] = {IconID="Heart",Type=5,Variant=10,SubType=5,Call=notCollected,IconGroup="hearts",Priority=14100},
+	["Heart"] = {IconID="Heart",Type=5,Variant=10,SubType=1,Call=notCollected,IconGroup="hearts",Priority=14100},
+	["HalfHeart"] = {IconID="HalfHeart",Type=5,Variant=10,SubType=2,Call=notCollected,IconGroup="hearts",Priority=14000},
 	
-	["Item"] = {IconID="Item",Type=5,Variant=100,SubType=-1,Call=function(pickup) return pickup.SubType ~= 0 end,IconGroup="collectibles",Priority=9000},
-	["Trinket"] = {IconID="Trinket",Type=5,Variant=350,SubType=-1,IconGroup="collectibles",Priority=8000},
-	
-	["BlackGrabBag"] = {IconID="BlackSack",Type=5,Variant=69,SubType=2,Call=notCollected,IconGroup="chests",Priority=6600},
-	["GrabBag"] = {IconID="Sack",Type=5,Variant=69,SubType=1,Call=notCollected,IconGroup="chests",Priority=6500},
-	["MegaChest"] = {IconID="MegaChest",Type=5,Variant=57,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=7800},
-	["WoodenChest"] = {IconID="WoodenChest",Type=5,Variant=56,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=7700},
-	["EternalChest"] = {IconID="EternalChest",Type=5,Variant=53,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=7600},
-	["GoldChest"] = {IconID="GoldChest",Type=5,Variant=60,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=7500},
-	["RedChest"] = {IconID="RedChest",Type=5,Variant=360,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=7400},
-	["Chest"] = {IconID="Chest",Type=5,Variant=50,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=7300},
-	["StoneChest"] = {IconID="StoneChest",Type=5,Variant=51,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=7200},
-	["SpikedChest"] = {IconID="SpikedChest",Type=5,Variant=52,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=7100},
-	["HauntedChest"] = {IconID="SpikedChest",Type=5,Variant=58,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=7100},
-	["MimicChest"] = {IconID="SpikedChest",Type=5,Variant=54,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=7000},
-	
-	["GoldenPill"] = {IconID="GoldenPill",Type=5,Variant=70,SubType=14,Call=notCollected,IconGroup="pills",Priority=6200},
-	["Pill"] = {IconID="Pill",Type=5,Variant=70,SubType=-1,Call=notCollected,IconGroup="pills",Priority=6000},
-	["GoldenKey"] = {IconID="GoldenKey",Type=5,Variant=30,SubType=2,Call=notCollected,IconGroup="keys",Priority=5300},
-	["ChargedKey"] = {IconID="ChargedKey",Type=5,Variant=30,SubType=4,Call=notCollected,IconGroup="keys",Priority=5200},
-	["Key"] = {IconID="Key",Type=5,Variant=30,SubType=1,Call=notCollected,IconGroup="keys",Priority=5000},
-	["GoldenBomb"] = {IconID="GoldenBomb",Type=5,Variant=40,SubType=4,Call=notCollected,IconGroup="bombs",Priority=4200},
-	["Bomb"] = {IconID="Bomb",Type=5,Variant=40,SubType=1,Call=notCollected,IconGroup="bombs",Priority=4000},
-	["GoldenCoin"] = {IconID="GoldenCoin",Type=5,Variant=20,SubType=7,Call=notCollected,IconGroup="coins",Priority=3200},
-	["Coin"] = {IconID="Coin",Type=5,Variant=20,SubType=-1,Call=notCollected,IconGroup="coins",Priority=3000},
-	["GoldenBattery"] = {IconID="GoldenBattery",Type=5,Variant=90,SubType=4,Call=notCollected,IconGroup="batteries",Priority=2200},
-	["Battery"] = {IconID="Battery",Type=5,Variant=90,SubType=-1,Call=notCollected,IconGroup="batteries",Priority=2000},
-	["Card"] = {IconID="Card",Type=5,Variant=300,SubType=-1,Call=notCollected,IconGroup="cards",Priority=1000},
-	["RuneShard"] = {IconID="Rune",Type=5,Variant=300,SubType=55,Call=notCollected,IconGroup="runes",Priority=1100},
-	["Poop"] = {IconID="Poop",Type=5,Variant=42,SubType=0,Call=notCollected,IconGroup="bombs",Priority=1200},
-	
-	["Confessional"] = {IconID="Confessional",Type=6,Variant=17,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=700},
-	["CraneGame"] = {IconID="CraneGame",Type=6,Variant=16,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=600},
-	["RestockMachine"] = {IconID="RestockMachine",Type=6,Variant=10,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=500},
-	["DressingTable"] = {IconID="DressingTable",Type=6,Variant=12,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=400},
-	["DonationMachine"] = {IconID="DonationMachine",Type=6,Variant=8,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=300},
-	["FortuneMachine"] = {IconID="FortuneMachine",Type=6,Variant=3,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=200},
-	["BloodDonationMachine"] = {IconID="BloodDonationMachine",Type=6,Variant=2,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=100},
-	["Slot"] = {IconID="Slot",Type=6,Variant=1,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=0},
+	["Item"] = {IconID="Item",Type=5,Variant=100,SubType=-1,Call=function(pickup) return pickup.SubType ~= 0 end,IconGroup="collectibles",Priority=13000},
 
-	["ChargeBeggar"] = {IconID="ChargeBeggar",Type=6,Variant=13,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=700},
-	["RottenBeggar"] = {IconID="RottenBeggar",Type=6,Variant=18,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=600},
-	["BombBeggar"] = {IconID="BombBeggar",Type=6,Variant=9,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=500},
-	["KeyBeggar"] = {IconID="KeyBeggar",Type=6,Variant=7,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=400},
-	["HellGame"] = {IconID="DemonBeggar",Type=6,Variant=15,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=300},
-	["DemonBeggar"] = {IconID="DemonBeggar",Type=6,Variant=5,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=200},
-	["ShellGame"] = {IconID="Beggar",Type=6,Variant=6,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=100},
-	["Beggar"] = {IconID="Beggar",Type=6,Variant=4,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=0},
+	["Trinket"] = {IconID="Trinket",Type=5,Variant=350,SubType=-1,IconGroup="trinkets",Priority=12000},
+	
+	["MegaChest"] = {IconID="MegaChest",Type=5,Variant=57,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=11900},
+	["GoldChest"] = {IconID="GoldChest",Type=5,Variant=60,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=11800},
+	["EternalChest"] = {IconID="EternalChest",Type=5,Variant=53,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=11700},
+	["WoodenChest"] = {IconID="WoodenChest",Type=5,Variant=56,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=11600},
+	["RedChest"] = {IconID="RedChest",Type=5,Variant=360,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=11500},
+	["Chest"] = {IconID="Chest",Type=5,Variant=50,SubType=-1,Call=chestNotCollected,IconGroup="chests",Priority=11400},
+	["BlackGrabBag"] = {IconID="BlackSack",Type=5,Variant=69,SubType=2,Call=notCollected,IconGroup="chests",Priority=11300},
+	["GrabBag"] = {IconID="Sack",Type=5,Variant=69,SubType=1,Call=notCollected,IconGroup="chests",Priority=11200},
+	["StoneChest"] = {IconID="StoneChest",Type=5,Variant=51,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=11100},
+	["SpikedChest"] = {IconID="SpikedChest",Type=5,Variant=52,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=11000},
+	["HauntedChest"] = {IconID="SpikedChest",Type=5,Variant=58,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=11000},
+	["MimicChest"] = {IconID="SpikedChest",Type=5,Variant=54,Call=chestNotCollected,SubType=-1,IconGroup="chests",Priority=11000},
+	
+	["Rune"] = {IconID="Rune",Type=5,Variant=300,SubType=-1,Call=notCollected,IconGroup="runes",Priority=10000,Condition=function(pickup) return Isaac.GetItemConfig():GetCard(pickup.SubType):IsRune() end},
+
+	["Card"] = {IconID="Card",Type=5,Variant=300,SubType=-1,Call=notCollected,IconGroup="cards",Priority=9000},
+
+	["GoldenPill"] = {IconID="GoldenPill",Type=5,Variant=70,SubType=14,Call=notCollected,IconGroup="pills",Priority=8100},
+	["Pill"] = {IconID="Pill",Type=5,Variant=70,SubType=-1,Call=notCollected,IconGroup="pills",Priority=8000},
+
+	["ChargedKey"] = {IconID="ChargedKey",Type=5,Variant=30,SubType=4,Call=notCollected,IconGroup="keys",Priority=7200},
+	["GoldenKey"] = {IconID="GoldenKey",Type=5,Variant=30,SubType=2,Call=notCollected,IconGroup="keys",Priority=7100},
+	["Key"] = {IconID="Key",Type=5,Variant=30,SubType=-1,Call=notCollected,IconGroup="keys",Priority=7000},
+
+	["GoldenBomb"] = {IconID="GoldenBomb",Type=5,Variant=40,SubType=4,Call=notCollected,IconGroup="bombs",Priority=6100},
+	["Bomb"] = {IconID="Bomb",Type=5,Variant=40,SubType=-1,Call=notCollected,IconGroup="bombs",Priority=6000},
+
+	["Poop"] = {IconID="Poop",Type=5,Variant=42,SubType=-1,Call=notCollected,IconGroup="poops",Priority=5000},
+
+	["GoldenCoin"] = {IconID="GoldenCoin",Type=5,Variant=20,SubType=7,Call=notCollected,IconGroup="coins",Priority=4100},
+	["Coin"] = {IconID="Coin",Type=5,Variant=20,SubType=-1,Call=notCollected,IconGroup="coins",Priority=4000},
+
+	["GoldenBattery"] = {IconID="GoldenBattery",Type=5,Variant=90,SubType=4,Call=notCollected,IconGroup="batteries",Priority=3100},
+	["Battery"] = {IconID="Battery",Type=5,Variant=90,SubType=-1,Call=notCollected,IconGroup="batteries",Priority=3000},
+
+	["ChargeBeggar"] = {IconID="ChargeBeggar",Type=6,Variant=13,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2500},
+	["BombBeggar"] = {IconID="BombBeggar",Type=6,Variant=9,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2400},
+	["KeyBeggar"] = {IconID="KeyBeggar",Type=6,Variant=7,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2300},
+	["HellGame"] = {IconID="DemonBeggar",Type=6,Variant=15,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2200},
+	["DemonBeggar"] = {IconID="DemonBeggar",Type=6,Variant=5,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2200},
+	["RottenBeggar"] = {IconID="RottenBeggar",Type=6,Variant=18,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2100},
+	["ShellGame"] = {IconID="Beggar",Type=6,Variant=6,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2000},
+	["Beggar"] = {IconID="Beggar",Type=6,Variant=4,SubType=-1,Call=slotNotDead,IconGroup="beggars",Priority=2000},
+
+	["Confessional"] = {IconID="Confessional",Type=6,Variant=17,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1700},
+	["RestockMachine"] = {IconID="RestockMachine",Type=6,Variant=10,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1600},
+	["CraneGame"] = {IconID="CraneGame",Type=6,Variant=16,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1500},
+	["FortuneMachine"] = {IconID="FortuneMachine",Type=6,Variant=3,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1400},
+	["BloodDonationMachine"] = {IconID="BloodDonationMachine",Type=6,Variant=2,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1300},
+	["Slot"] = {IconID="Slot",Type=6,Variant=1,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1200},
+	["DonationMachine"] = {IconID="DonationMachine",Type=6,Variant=8,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1100},
+	["DressingTable"] = {IconID="DressingTable",Type=6,Variant=12,SubType=-1,Call=slotNotDead,IconGroup="slots",Priority=1000},
 }
-for i=32,41 do -- These can be better once the api has more stuff in ItemConfig_Card
-	MinimapAPI.PickupList["Rune"..i] = {IconID="Rune",Type=5,Variant=300,SubType=i,Call=notCollected,IconGroup="runes",Priority=1100}
-end
-for i=81,97 do
-	MinimapAPI.PickupList["Soul"..i] = {IconID="Rune",Type=5,Variant=300,SubType=i,Call=notCollected,IconGroup="runes",Priority=1100}
-end
 
--- IsPrespawnObject is used for grid entities that exist on room creation. These objects are mostly defined by very big Type IDs
+-- IsPrespawnObject can be used for grid entities that exist on room creation. These objects are mostly defined by very big Type IDs
 MinimapAPI.GridEntityList = {	
-	["Ladder"] = {IconID="Ladder",Type=18,Variant=-1,Priority=12000},
+	["Ladder"] = {IconID="Ladder",Type=18,Variant=-1,Priority=0},
 }
 
 MinimapAPI.IconList = {

--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -251,7 +251,7 @@ function MinimapAPI:GetDoorSlotValue(doorgroup, doordir)
 end
 
 local defaultCustomPickupPriority = 12999 --more than vanilla, less than other potential custom pickups
-function MinimapAPI:AddPickup(id, iconid, typ, variant, subtype, call, icongroup, priority)
+function MinimapAPI:AddPickup(id, iconid, typ, variant, subtype, call, icongroup, priority, condition)
 	local newPickup
 	if type(id) == "table" and iconid == nil then
 		local t = id
@@ -266,7 +266,8 @@ function MinimapAPI:AddPickup(id, iconid, typ, variant, subtype, call, icongroup
 			SubType = t.SubType or -1,
 			Call = t.Call,
 			IconGroup = t.IconGroup,
-			Priority = t.Priority or defaultCustomPickupPriority
+			Priority = t.Priority or defaultCustomPickupPriority,
+			Condition = t.Condition,
 		}
 	else
 		if type(iconid) == "table" then
@@ -279,7 +280,8 @@ function MinimapAPI:AddPickup(id, iconid, typ, variant, subtype, call, icongroup
 			SubType = subtype or -1,
 			Call = call,
 			IconGroup = icongroup,
-			Priority = priority or defaultCustomPickupPriority
+			Priority = priority or defaultCustomPickupPriority,
+			Condition = condition,
 		}
 	end
 	MinimapAPI.PickupList[id] = newPickup
@@ -471,8 +473,10 @@ function MinimapAPI:GetCurrentRoomPickupIDs() --gets pickup icon ids for current
 						if (not toPickup) or (not toPickup:IsShopItem()) then
 							if v.Variant == -1 or ent.Variant == v.Variant then
 								if v.SubType == -1 or ent.SubType == v.SubType then
-									ent:GetData().MinimapAPIPickupID = i
-									success = true
+									if (not v.Condition) or v.Condition(ent) then
+										ent:GetData().MinimapAPIPickupID = i
+										success = true
+									end
 								end
 							end
 						end


### PR DESCRIPTION
- Added new Condition variable to MinimapAPI:AddPickup() that lets you differentiate 2 pickups of the same type, variant, and subtype with a function.
- Using the above, overhaul cards and rune detection by detecting ItemConfig_Card.PickupSubtype instead.
- The treasure, blue map, compass, and mind mapflags are detected by checking if you have the item, like vanilla does.
- Overhaul all the pickup priorities to be closer to vanilla instead of all over the place.
- Separate icongroups for some pickups that are separated in vanilla.