### PR TITLE
add option to show true room sizes in the void

### DIFF
--- a/scripts/minimapapi/config_menu.lua
+++ b/scripts/minimapapi/config_menu.lua
@@ -49,6 +49,9 @@ if modconfigexists then
 				end
 				MinimapAPI:FirstMapDisplayMode()
 				MinimapAPI.Config.ConfigPreset = currentNum
+				if Game():GetLevel():GetStage() == LevelStage.STAGE7 then
+					MinimapAPI:LoadDefaultMap(0)
+				end
 			end,
 		}
 	)
@@ -320,6 +323,30 @@ if modconfigexists then
 			Info = {
 				"Enable this to display newly discovered",
 				"secret rooms as a shadows instead of a normal rooms.",
+			}
+		}
+	)
+	
+		MCM.AddSetting(
+		"Minimap API",
+		"Map(2)",
+		{
+			Type = MCM.OptionType.BOOLEAN,
+			CurrentSetting = function()
+				return MinimapAPI.Config.OverrideVoid
+			end,
+			Display = function()
+				return "Show true room sizes in The Void: " .. (MinimapAPI.Config.OverrideVoid and "ON" or "OFF")
+			end,
+			OnChange = function(currentBool)
+				MinimapAPI.Config.OverrideVoid = currentBool
+				MinimapAPI.Config.ConfigPreset = 0
+				if Game():GetLevel():GetStage() == LevelStage.STAGE7 then
+					MinimapAPI:LoadDefaultMap(0) -- use dimension 0 just in case we're in the death certificate dimension
+				end
+			end,
+			Info = {
+				"Enable this to easily find Delirium on the map."
 			}
 		}
 	)

--- a/scripts/minimapapi/dsscompat.lua
+++ b/scripts/minimapapi/dsscompat.lua
@@ -89,7 +89,10 @@ function MinimapAPI:AddDSSMenu(DSSModName, dssmod, MenuProvider)
                                 MinimapAPI.Config[i] = v
                             end
                         end
-        				MinimapAPI:FirstMapDisplayMode()
+                        MinimapAPI:FirstMapDisplayMode()
+                        if Game():GetLevel():GetStage() == LevelStage.STAGE7 then
+                            MinimapAPI:LoadDefaultMap(0)
+                        end
                     end,
                 },
                 {str = ''},
@@ -470,6 +473,23 @@ function MinimapAPI:AddDSSMenu(DSSModName, dssmod, MenuProvider)
                     store = function(var)
                         ResetPresetIfChanged(MinimapAPI.Config.VanillaSecretRoomDisplay, var == 1)
                         MinimapAPI.Config.VanillaSecretRoomDisplay = var == 1
+                    end,
+                },
+                {
+                    str = 'true room sizes',
+                    choices = {'on', 'off'},
+                    tooltip = {strset = {'show', 'true room', 'sizes in', 'the void', 'to easily', 'find', 'delirium' }},
+                    variable = 'OverrideVoid',
+                    setting = 1,
+                    load = function()
+                        return MinimapAPI.Config.OverrideVoid and 1 or 2
+                    end,
+                    store = function(var)
+                        ResetPresetIfChanged(MinimapAPI.Config.OverrideVoid, var == 1)
+                        MinimapAPI.Config.OverrideVoid = var == 1
+                        if Game():GetLevel():GetStage() == LevelStage.STAGE7 then
+                            MinimapAPI:LoadDefaultMap(0)
+                        end
                     end,
                 },
             },

--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -635,7 +635,7 @@ function MinimapAPI:LoadDefaultMap(dimension)
 		local roomDescriptor, roomDim = GetRoomDescAndDimFromListIndex(i)
 		if roomDescriptor and roomDim == dimension 
 		and not added_descriptors[roomDescriptor] 
-		and GetPtrHash(cache.Level:GetRoomByIdx(roomDescriptor.SafeGridIndex)) == GetPtrHash(roomDescriptor)
+		and GetPtrHash(cache.Level:GetRoomByIdx(roomDescriptor.SafeGridIndex, dimension)) == GetPtrHash(roomDescriptor)
 		then
 			added_descriptors[roomDescriptor] = true
 			local t = {
@@ -692,31 +692,51 @@ function MinimapAPI:LoadDefaultMap(dimension)
 	if not (MinimapAPI:GetConfig("OverrideVoid") or MinimapAPI.OverrideVoid) then
 		if not game:IsGreedMode() then
 			if cache.Stage == LevelStage.STAGE7 then
-				for i,v in ipairs(MinimapAPI:GetLevel()) do
+				for i,v in ipairs(MinimapAPI:GetLevel(dimension)) do
 					if v.Descriptor.Data.Type == RoomType.ROOM_BOSS then
 						if v.Shape == RoomShape.ROOMSHAPE_2x2 then
 							-- Hide delirium room
-							if not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT0)) then
+							if not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT0), nil, dimension, true)
+							then
 								--
-							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP1)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT0)) then
+							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP1), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT0), nil, dimension, true)
+							then
 								v.DisplayPosition = v.Position + Vector(1,0)
-							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT1)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN1)) then
+							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT1), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN1), nil, dimension, true)
+							then
 								v.DisplayPosition = v.Position + Vector(1,1)
-							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT1)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN0)) then
+							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT1), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN0), nil, dimension, true)
+							then
 								v.DisplayPosition = v.Position + Vector(0,1)
 							end
 							v.Shape = RoomShape.ROOMSHAPE_1x1
 						elseif v.Shape == RoomShape.ROOMSHAPE_2x1 then
-							if not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN0)) then
+							if not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN0), nil, dimension, true)
+							then
 								--
-							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP1)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN1)) then
+							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP1), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN1), nil, dimension, true)
+							then
 								v.DisplayPosition = v.Position + Vector(1,0)
 							end
 							v.Shape = RoomShape.ROOMSHAPE_1x1
 						elseif v.Shape == RoomShape.ROOMSHAPE_1x2 then
-							if not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT0)) then
+							if not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.UP0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT0), nil, dimension, true)
+							then
 								--
-							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT1)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN0)) or not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT1)) then
+							elseif not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.RIGHT1), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.DOWN0), nil, dimension, true) or
+								not MinimapAPI:IsPositionFree(MinimapAPI:GetPositionRelativeToDoor(v,DoorSlot.LEFT1), nil, dimension, true)
+							then
 								v.DisplayPosition = v.Position + Vector(0,1)
 							end
 							v.Shape = RoomShape.ROOMSHAPE_1x1
@@ -1195,9 +1215,21 @@ function MinimapAPI:GetPositionRelativeToDoor(room, doorslot)
 	end
 end
 
-function MinimapAPI:IsPositionFree(position,roomshape)
+function MinimapAPI:IsPositionFree(position,roomshape,dimension,redRoomsAreFree)
 	roomshape = roomshape or 1
-	for _,room in ipairs(MinimapAPI:GetLevel()) do
+	dimension = dimension or MinimapAPI.CurrentDimension
+	redRoomsAreFree = redRoomsAreFree or false
+	
+	-- treat red rooms as free positions
+	if REPENTANCE and redRoomsAreFree then
+		local idx = MinimapAPI:GridVectorToIndex(position)
+		local roomDesc = cache.Level:GetRoomByIdx(idx, dimension)
+		if roomDesc.Flags & RoomDescriptor.FLAG_RED_ROOM == RoomDescriptor.FLAG_RED_ROOM then
+			return true
+		end
+	end
+	
+	for _,room in ipairs(MinimapAPI:GetLevel(dimension)) do
 		for _,pos in ipairs(MinimapAPI.RoomShapePositions[room.Shape]) do
 			for _,pos2 in ipairs(MinimapAPI.RoomShapePositions[roomshape]) do
 				local p = pos + room.Position


### PR DESCRIPTION
This update allows dynamically updating the OverrideVoid setting from MCM or DSS... rather than it just being a hidden config option.

Due to changing the setting in the death certificate dimension while in the void, I had to add some additional dimensional plumbing.

Also if toggling this setting, you don't want the 1x1 boss room to only connect to any surrounding red rooms (if any), so I added a check for that.

This works for me in Repentance. Basic checking in AB+ seemed good, but I was limited as changing some settings seemed to cause error messages in the console. I double-checked by reverting my changes and saw the same thing.