### PR TITLE
fix Nice Journey teleport using player's active

### DIFF
--- a/scripts/minimapapi/nicejourney.lua
+++ b/scripts/minimapapi/nicejourney.lua
@@ -17,6 +17,7 @@ local lastMousePos = Vector(-1,-1)
 local TeleportMarkerSprite = Sprite()
 TeleportMarkerSprite:Load("gfx/ui/minimapapi/teleport_marker.anm2", true)
 TeleportMarkerSprite:SetFrame("Marker", 0)
+local teleportTarget
 
 local function niceJourney_ExecuteCmd(_, cmd, params)
     if cmd == "mapitel" then
@@ -232,7 +233,7 @@ local function niceJourney_PostRender()
     local TABpressed = Input.IsActionPressed(ButtonAction.ACTION_MAP, playerController)
     HandleMoveCursorWithButtons()
 
-    local teleportTarget = nil
+    teleportTarget = nil
     for _, room in pairs(MinimapAPI:GetLevel()) do
         if room:IsValidTeleportTarget()
             and (room.Descriptor or room.TeleportHandler)
@@ -277,6 +278,18 @@ local function niceJourney_PostRender()
     end
 
 end
+
+MinimapAPI:AddPriorityCallback(
+    ModCallbacks.MC_PRE_USE_ITEM,
+    CallbackPriority.DEFAULT,
+    function(self, id, rng, player, useFlags, activeSlot, customVarData)
+        if activeSlot == ActiveSlot.SLOT_PRIMARY and teleportTarget then
+            local p1 = Isaac.GetPlayer(0)
+            p1:SetActiveCharge(2 * p1:GetActiveCharge(ActiveSlot.SLOT_PRIMARY), ActiveSlot.SLOT_PRIMARY)
+            return true
+        end
+    end
+)
 
 local addRenderCall = true
 


### PR DESCRIPTION
Nice Journey's teleport ability will no longer use main player's active item if it's charged. the solution I came up with is actually pretty weird, feel free to modify it (possibly by hooking into POST_PEFFECT_UPDATE to regain charges).
- runs on PRE_USE_ITEM;
- before returning true, give twice as many charges to an item as it had before. this has to be done because returning true still discharges the item (thanks API). for example, if you have the D6 with 6 charges, you increase it to 12, then it's "used" once, so the charge goes back to 6;
- breaks with The Battery (depletes all the extra charges). but hey, it's still better than the way it'd been before.