### PR TITLE
Add the Aprils Fool challenge map randomization

### DIFF
--- a/scripts/minimapapi/main.lua
+++ b/scripts/minimapapi/main.lua
@@ -1427,6 +1427,10 @@ function MinimapAPI:updatePlayerPos()
 	local currentroom = cache.RoomDescriptor
 	if currentroom.GridIndex < 0 then
 		playerMapPos = Vector(-32768,-32768)
+	elseif Isaac.GetChallenge() == Challenge.CHALLENGE_APRILS_FOOL then
+		local level = game:GetLevel()
+		local randomRoom = level:GetRooms():Get(level:GetRoomByIdx(level:GetRandomRoomIndex(false, cache.RoomDescriptor.DecorationSeed), MinimapAPI.CurrentDimension).ListIndex)
+		playerMapPos = MinimapAPI:GridIndexToVector(randomRoom.GridIndex) + MinimapAPI.RoomShapeGridPivots[randomRoom.Data.Shape]
 	else
 		playerMapPos = MinimapAPI:GridIndexToVector(currentroom.GridIndex) + MinimapAPI.RoomShapeGridPivots[currentroom.Data.Shape]
 	end


### PR DESCRIPTION
In vanilla the aprils fool challenge causes what room isaac is currently in to be shown as a completely random room on the map. I added that functionality in minimap api, while playing the aprils fool challenge it causes the map position to be random.